### PR TITLE
Fix #8: Add Gemfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 _site/
 .sass-cache/
+.jekyll-cache/
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'jekyll', '~> 3.0'
+gem 'redcarpet'
+gem 'pygments.rb'

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ Lemma Theme
 Lemma is yet another simple responsive theme for Jekyll.
 
 
+Development
+-------
+1. Clone this repository
+1. `cd` to the cloned repo
+1. `$ bundle install`
+1. `$ bundle exec jekyll build`
+
 License
 -------
 


### PR DESCRIPTION
To make it easier for co-developers to set this project up locally, there should be a Gemfile listing the used dependencies.

I've verified that it now works to
```console
$ bundle install
$ bundle exec jekyll build
```

I added this to the `README.md` as well.

Fixes #8

As a part of [#hacktoberfest](https://github.com/topics/hacktoberfest) :)